### PR TITLE
Add release workflow

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,20 +1,17 @@
 changelog:
   categories:
-    - title: ⚠️ Security issues
+    - title: 🎉 New features
       labels:
-        - security
+        - Feature
     - title: ⭐ Enhancements
       labels:
-        - enhancement
+        - Enhancement
     - title: 🐞 Bug fixes
       labels:
-        - bug
-    - title: 🔨 Dependency upgrades
-      labels:
-        - dependencies
+        - Bug
     - title: 📝 Documentation
       labels:
-        - documentation
+        - Documentation
     - title: Other changes
       labels:
         - "*"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,20 @@
+changelog:
+  categories:
+    - title: ⚠️ Security issues
+      labels:
+        - security
+    - title: ⭐ Enhancements
+      labels:
+        - enhancement
+    - title: 🐞 Bug fixes
+      labels:
+        - bug
+    - title: 🔨 Dependency upgrades
+      labels:
+        - dependencies
+    - title: 📝 Documentation
+      labels:
+        - documentation
+    - title: Other changes
+      labels:
+        - "*"

--- a/.github/workflows/orlib_cocoapod.yml
+++ b/.github/workflows/orlib_cocoapod.yml
@@ -1,9 +1,10 @@
 name: Push CocoaPod on Tag
 
 on:
+  # Push on release tags
   push:
     tags:
-      - '*'
+      - '[0-9]+.[0-9]+.[0-9]+'
 
   # Manual trigger
   workflow_dispatch:
@@ -11,7 +12,7 @@ on:
 jobs:
   push_pod:
     runs-on: macos-latest
-    
+
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/orlib_cocoapod.yml
+++ b/.github/workflows/orlib_cocoapod.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - '*'
 
+  # Manual trigger
+  workflow_dispatch:
+
 jobs:
   push_pod:
     runs-on: macos-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: Release
+
+on:
+  # Manual trigger
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  contents: write
+
+jobs:
+
+  build:
+    name: Release
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Get ORLib spec information
+        id: orlib_spec
+        run: |
+          echo "version=$(cat ORLib/ORLib.podspec | sed 's# ##g' | grep 'spec.version=' | cut -d'=' -f2 | sed 's#"##g')" >> $GITHUB_OUTPUT
+
+      - name: Create release
+        run: |
+          git tag $ORLIB_VERSION
+          git push origin tag $ORLIB_VERSION
+          gh workflow run orlib_cocoapod.yml --ref $ORLIB_VERSION
+          gh release create $ORLIB_VERSION --generate-notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ORLIB_VERSION: ${{ steps.orlib_spec.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
         run: |
           echo "version=$(cat ORLib/ORLib.podspec | sed 's# ##g' | grep 'spec.version=' | cut -d'=' -f2 | sed 's#"##g')" >> $GITHUB_OUTPUT
 
+      # When the 'github.token' is used events are not generated to prevent users from accidentally creating recursive workflow runs.
+      # See: https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
       - name: Create release
         run: |
           git tag $ORLIB_VERSION


### PR DESCRIPTION
* Creates a tag based on the ORLib version
* Creates a release with release notes using the tag
* Triggers the orlib_cocoapod.yml to push the ORLib CocoaPod to Trunk

Related to https://github.com/openremote/openremote/issues/1513.