### PR TITLE
Configure concurrency to cancel "In progress" actions

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -8,6 +8,10 @@ on:
     tags-ignore:
       - '*.*'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   build:
@@ -15,12 +19,6 @@ jobs:
     runs-on: macos-latest
 
     steps:
-
-      - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@85880fa0301c86cca9da44039ee3bb12d3bedbfa # 0.12.1
-        with:
-          access_token: ${{ github.token }}
-
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 


### PR DESCRIPTION
The styfle/cancel-workflow-action is no longer necessary to accomplish this nowadays.

See: https://github.com/styfle/cancel-workflow-action