### PR TITLE
Fix for possible crashing on start

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -24,7 +24,7 @@ jobs:
 
   build:
     name: CI/CD
-    runs-on: macos-15 # is not the macos-latest, which should be by the end of August 2025
+    runs-on: macos-latest
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -30,39 +30,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
-      - name: Install the Apple certificate and provisioning profile
+      - name: Install App Store Connect API key
         env:
-          BUILD_CERTIFICATE_BASE64: ${{ secrets.APPLE_BUILD_CERTIFICATE_BASE64 }}
-          P12_PASSWORD: ${{ secrets.APPLE_BUILD_CERT_PASSWORD }}
-          GENERIC_APP_PROVISION_PROFILE: ${{ secrets.APPLE_GENERIC_APP_PROVISION_PROFILE_BASE64 }}
-          NOTIFICATION_SERVICE_PROVISION_PROFILE: ${{ secrets.APPLE_NOTIFICATION_SERVICE_PROVISION_PROFILE_BASE64 }}
-          KEYCHAIN_PASSWORD: ${{ secrets.APPLE_KEYCHAIN_PASSWORD }}
+          APP_STORE_CONNECT_PRIVATE_KEY: ${{ secrets.APP_STORE_CONNECT_PRIVATE_KEY }}
         run: |
-          # create variables
-          CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
-          PP_PATH=$RUNNER_TEMP/build_pp.mobileprovision
-          NOTIDICATION_SERVICE_PP_PATH=$RUNNER_TEMP/notification_service_pp.mobileprovision
-          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
-
-          # import certificate and provisioning profile from secrets
-          echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode -o $CERTIFICATE_PATH
-          echo -n "$GENERIC_APP_PROVISION_PROFILE" | base64 --decode -o $PP_PATH
-          echo -n "$NOTIFICATION_SERVICE_PROVISION_PROFILE" | base64 --decode -o $NOTIDICATION_SERVICE_PP_PATH
-
-          # create temporary keychain
-          security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-
-          # import certificate to keychain
-          security import $CERTIFICATE_PATH -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
-          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-          security list-keychain -d user -s $KEYCHAIN_PATH
-
-          # apply provisioning profile
-          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
-          cp $PP_PATH ~/Library/MobileDevice/Provisioning\ Profiles
-          cp $NOTIDICATION_SERVICE_PP_PATH ~/Library/MobileDevice/Provisioning\ Profiles
+          mkdir -p ~/private_keys
+          echo -n "$APP_STORE_CONNECT_PRIVATE_KEY" > ~/private_keys/AuthKey_${{ secrets.APP_STORE_CONNECT_KEY_ID }}.p8
 
       - name: Swift Package Manager cache
         uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
@@ -79,7 +52,11 @@ jobs:
           -sdk iphoneos \
           -configuration Release \
           -destination generic/platform=iOS \
-          clean archive          
+          -allowProvisioningUpdates \
+          -authenticationKeyPath ~/private_keys/AuthKey_${{ secrets.APP_STORE_CONNECT_KEY_ID }}.p8 \
+          -authenticationKeyID ${{ secrets.APP_STORE_CONNECT_KEY_ID }} \
+          -authenticationKeyIssuerID ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }} \
+          clean archive
 
       # - name: Export IPA
       #   env:
@@ -87,7 +64,7 @@ jobs:
       #   run: |
       #     EXPORT_OPTS_PATH=$RUNNER_TEMP/ExportOptions.plist
       #     echo -n "$EXPORT_OPTIONS_PLIST" | base64 --decode -o $EXPORT_OPTS_PATH
-      #     xcodebuild -exportArchive -archivePath $RUNNER_TEMP/genericapp.xcarchive -exportOptionsPlist $EXPORT_OPTS_PATH -exportPath $RUNNER_TEMP/build          
+      #     xcodebuild -exportArchive -archivePath $RUNNER_TEMP/genericapp.xcarchive -exportOptionsPlist $EXPORT_OPTS_PATH -exportPath $RUNNER_TEMP/build
 
       # - name: Upload IPAs
       #   if: success()

--- a/GenericApp/GenericApp/AppDelegate.swift
+++ b/GenericApp/GenericApp/AppDelegate.swift
@@ -46,7 +46,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, URLSessionDelegate {
         let documentsDirectory = paths[0]
         let fileName = "\(Date()).log"
         let logFilePath = (documentsDirectory as NSString).appendingPathComponent(fileName)
-        freopen(logFilePath.cString(using: String.Encoding.ascii)!, "a+", stderr)
+        if let cPath = logFilePath.cString(using: .utf8) {
+            freopen(cPath, "a+", stderr)
+        }
 
         if launchOptions?[UIApplication.LaunchOptionsKey.location] != nil {
             NSLog("%@", "App started from location update")

--- a/GenericApp/GenericApp/AppDelegate.swift
+++ b/GenericApp/GenericApp/AppDelegate.swift
@@ -44,11 +44,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate, URLSessionDelegate {
 
 
         // Redirects NSLog calls to file
-        let documentsDirectory = paths[0]
-        let fileName = "\(Date()).log"
-        let logFilePath = (documentsDirectory as NSString).appendingPathComponent(fileName)
-        if let cPath = logFilePath.cString(using: .utf8) {
-            freopen(cPath, "a+", stderr)
+        if let documentsDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first {
+            let fileName = "\(Date()).log"
+            let logFilePath = documentsDirectory.appendingPathComponent(fileName).path
+            if let cPath = logFilePath.cString(using: .utf8) {
+                freopen(cPath, "a+", stderr)
+            }
         }
 
         if launchOptions?[UIApplication.LaunchOptionsKey.location] != nil {

--- a/GenericApp/GenericApp/AppDelegate.swift
+++ b/GenericApp/GenericApp/AppDelegate.swift
@@ -42,7 +42,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, URLSessionDelegate {
         UNUserNotificationCenter.current().delegate = self
         // if the app was launched because of geofencing
 
-        let paths = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)
+
+        // Redirects NSLog calls to file
         let documentsDirectory = paths[0]
         let fileName = "\(Date()).log"
         let logFilePath = (documentsDirectory as NSString).appendingPathComponent(fileName)


### PR DESCRIPTION
- C string functions work with byte arrays and are perfectly happy with UTF-8, which is backward-compatible with ASCII.
- iOS file paths support full Unicode.

This way we handle the nil properly and also use modern utf8

fix #39 